### PR TITLE
remove old requirement enum34

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,4 @@ cbapi==1.3.4
 simplejson
 tcex==1.0.7
 PyYAML==5.1.2
-enum34
 jinja2

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ class install_cb(Command):
             outputs = self.get_outputs()
             if self.root:               # strip any package prefix
                 root_len = len(self.root)
-                for counter in xrange(len(outputs)):
+                for counter in range(len(outputs)):
                     outputs[counter] = outputs[counter][root_len:]
             self.execute(write_file,
                          (self.record, outputs),


### PR DESCRIPTION
Remove enum34 because it is no longer required on python3.6+